### PR TITLE
fix(version): use latest version from npm info

### DIFF
--- a/src/app/[pkg]/page.tsx
+++ b/src/app/[pkg]/page.tsx
@@ -76,6 +76,7 @@ export default async function Page({ params, searchParams }: Props) {
               repo={repo}
               pkg={pkg}
               accent={accent}
+              version={info.version}
               versionRollout={versionRollout}
             />
             <CopyImage />

--- a/src/components/npm-package/index.tsx
+++ b/src/components/npm-package/index.tsx
@@ -19,6 +19,7 @@ import { GithubAvatar } from "@/components/npm-package/github-avatar";
 export type NpmPackageProps = Omit<EmbedFrameProps, "Icon" | "children"> & {
   pkg: string;
   repo: string;
+  version: string;
   accent?: string;
   versionRollout?: number;
   children?: React.ReactNode;
@@ -27,6 +28,7 @@ export type NpmPackageProps = Omit<EmbedFrameProps, "Icon" | "children"> & {
 export const NpmPackage: React.FC<NpmPackageProps> = async ({
   pkg,
   repo,
+  version,
   accent = "text-blue-500",
   className,
   children,
@@ -69,13 +71,13 @@ export const NpmPackage: React.FC<NpmPackageProps> = async ({
                   <FiDownload />
                   <dd>{formatStatNumber(npm.allTime)}</dd>
                 </dl>
-                {github.version && (
+                {version && (
                   <dl
                     className="flex items-center gap-1"
                     title="Latest version"
                   >
                     <FiTag />
-                    <span>{github.version}</span>
+                    <span>{version}</span>
                   </dl>
                 )}
                 {github.license && (
@@ -113,7 +115,7 @@ export const NpmPackage: React.FC<NpmPackageProps> = async ({
               versions={npm.versions}
               accent={accent}
               limit={versionRollout}
-              latestVersion={github.version}
+              latestVersion={version}
             />
           )}
           <SvgCurveGraph

--- a/src/lib/fetch-npm.ts
+++ b/src/lib/fetch-npm.ts
@@ -79,9 +79,10 @@ export async function getPkgInfo(pkg: string) {
   return get<{
     name: string;
     description: string;
+    version: string;
     repository: {
       url: string;
-    }
+    };
   }>(url);
 }
 


### PR DESCRIPTION
github could be wrong, like in a monorepo (eg. https://npm-stat.link/react-instantsearch)