### PR TITLE
feat(versionRollout): add semver sort option

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "react-icons": "^4.12.0",
     "sonner": "^1.3.1",
     "tailwind-merge": "^2.2.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/semver": "^7.5.6",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   react-icons:
     specifier: ^4.12.0
     version: 4.12.0(react@18.2.0)
+  semver:
+    specifier: ^7.5.4
+    version: 7.5.4
   sonner:
     specifier: ^1.3.1
     version: 1.3.1(react-dom@18.2.0)(react@18.2.0)
@@ -43,6 +46,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18
     version: 18.2.18
+  '@types/semver':
+    specifier: ^7.5.6
+    version: 7.5.6
   autoprefixer:
     specifier: ^10.0.1
     version: 10.4.16(postcss@8.4.33)
@@ -341,6 +347,10 @@ packages:
 
   /@types/scheduler@0.16.8:
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
+    dev: true
+
+  /@types/semver@7.5.6:
+    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
   /@typescript-eslint/parser@6.18.0(eslint@8.56.0)(typescript@5.3.3):
@@ -1829,7 +1839,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2359,7 +2368,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /set-function-length@1.1.1:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
@@ -2823,7 +2831,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}

--- a/src/app/[pkg]/page.tsx
+++ b/src/app/[pkg]/page.tsx
@@ -13,6 +13,7 @@ type Props = {
   };
   searchParams: {
     count?: string;
+    sort?: string;
   };
 };
 
@@ -54,6 +55,11 @@ export default async function Page({ params, searchParams }: Props) {
   if (Number.isNaN(versionRollout) || versionRollout < 5) {
     versionRollout = 5;
   }
+  let versionRolloutSort: "count" | "semver" =
+    (searchParams.sort as "count" | "semver") ?? "count";
+  if (!["count", "semver"].includes(versionRolloutSort)) {
+    versionRolloutSort = "count";
+  }
   try {
     const info = await getPkgInfo(pkg as string);
     if (info.repository?.url) {
@@ -77,6 +83,7 @@ export default async function Page({ params, searchParams }: Props) {
               pkg={pkg}
               accent={accent}
               versionRollout={versionRollout}
+              versionRolloutSort={versionRolloutSort}
             />
             <CopyImage />
             <Footer />

--- a/src/components/npm-package/index.tsx
+++ b/src/components/npm-package/index.tsx
@@ -162,7 +162,7 @@ const sortFunctions: Record<
   ) => number
 > = {
   count: ([, a], [, b]) => b - a,
-  semver: ([a], [b]) => compareBuild(a, b),
+  semver: ([a], [b]) => compareBuild(b, a),
 };
 
 const VersionRollout: React.FC<VersionRolloutProps> = ({

--- a/src/components/npm-package/index.tsx
+++ b/src/components/npm-package/index.tsx
@@ -9,6 +9,7 @@ import {
   FiStar,
   FiTag,
 } from "react-icons/fi";
+import { compareBuild } from "semver";
 
 import { twMerge } from "tailwind-merge";
 import { SvgCurveGraph } from "../svg-curve-graph";
@@ -21,6 +22,7 @@ export type NpmPackageProps = Omit<EmbedFrameProps, "Icon" | "children"> & {
   repo: string;
   accent?: string;
   versionRollout?: number;
+  versionRolloutSort?: "count" | "semver";
   children?: React.ReactNode;
 };
 
@@ -31,6 +33,7 @@ export const NpmPackage: React.FC<NpmPackageProps> = async ({
   className,
   children,
   versionRollout = 5,
+  versionRolloutSort = "count",
   ...props
 }) => {
   try {
@@ -114,6 +117,7 @@ export const NpmPackage: React.FC<NpmPackageProps> = async ({
               accent={accent}
               limit={versionRollout}
               latestVersion={github.version}
+              sort={versionRolloutSort}
             />
           )}
           <SvgCurveGraph
@@ -144,7 +148,19 @@ type VersionRolloutProps = {
   versions: Record<string, number>;
   accent: string;
   limit: number;
+  sort: "count" | "semver";
   latestVersion?: string;
+};
+
+const sortFunctions: Record<
+  VersionRolloutProps["sort"],
+  (
+    a: [version: string, count: number],
+    b: [version: string, count: number],
+  ) => number
+> = {
+  count: ([, a], [, b]) => b - a,
+  semver: ([a], [b]) => compareBuild(a, b),
 };
 
 const VersionRollout: React.FC<VersionRolloutProps> = ({
@@ -152,8 +168,12 @@ const VersionRollout: React.FC<VersionRolloutProps> = ({
   accent,
   latestVersion,
   limit,
+  sort,
 }) => {
-  const data = Object.entries(versions).slice(0, limit);
+  const data = Object.entries(versions)
+    .slice()
+    .sort(sortFunctions[sort] ?? sortFunctions["count"])
+    .slice(0, limit);
   const totalCount = Object.values(versions).reduce(
     (sum, count) => sum + count,
     0,


### PR DESCRIPTION
if you put `?sort=semver`, the versions will be shown based on semver version, not based on download count