### PR TITLE
fix: handle longer content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+  }
+}

--- a/src/components/copy-image.tsx
+++ b/src/components/copy-image.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { MouseEvent } from "react";
-import { toPng } from "html-to-image";
+import { toBlob } from "html-to-image";
 import { toast } from "sonner";
 
 function updateStyle() {
@@ -32,14 +32,14 @@ function updateStyle() {
 
 const copyImage = (event: MouseEvent<HTMLButtonElement>) => {
   event.preventDefault();
-  const div = document.querySelector("section");
+  const div = document.querySelector("#embed-frame") as HTMLElement | null;
   if (!div) return;
 
   const reset = updateStyle();
 
   toast.promise(
-    toPng(div).then(async (dataUrl) => {
-      const blob = await fetch(dataUrl).then((r) => r.blob());
+    toBlob(div).then(async (blob) => {
+      if (!blob) throw new Error("Failed to convert html to blob");
       const item = new ClipboardItem({ "image/png": blob });
       await navigator.clipboard.write([item]);
       reset();

--- a/src/components/copy-image.tsx
+++ b/src/components/copy-image.tsx
@@ -3,38 +3,37 @@ import { MouseEvent } from "react";
 import { toPng } from "html-to-image";
 import { toast } from "sonner";
 
+function updateStyle() {
+  const versionRollout = document.querySelector(
+    "#version-rollout",
+  ) as HTMLElement | null;
+  const figure = document.querySelector("figure");
+  if (
+    !versionRollout ||
+    !figure ||
+    versionRollout.scrollHeight <= versionRollout.clientHeight
+  )
+    return () => {};
+
+  // update style to render full height image
+  const lastOverflow = versionRollout.style.overflow;
+  const lastMaxHeight = versionRollout.style.maxHeight;
+  const lastFigureMaxHeight = figure.style.maxHeight;
+
+  versionRollout.style.overflow = "visible";
+  versionRollout.style.maxHeight = "none";
+  figure.style.maxHeight = "none";
+  return () => {
+    versionRollout.style.overflow = lastOverflow;
+    versionRollout.style.maxHeight = lastMaxHeight;
+    figure.style.maxHeight = lastFigureMaxHeight;
+  };
+}
+
 const copyImage = (event: MouseEvent<HTMLButtonElement>) => {
   event.preventDefault();
   const div = document.querySelector("section");
   if (!div) return;
-
-  const versionRollout = div.querySelector(
-    "#version-rollout",
-  ) as HTMLElement | null;
-  const figure = div.querySelector("figure") as HTMLElement | null;
-
-  function updateStyle() {
-    if (
-      !versionRollout ||
-      !figure ||
-      versionRollout.scrollHeight <= versionRollout.clientHeight
-    )
-      return () => {};
-
-    // update style to render full height image
-    const lastOverflow = versionRollout.style.overflow;
-    const lastMaxHeight = versionRollout.style.maxHeight;
-    const lastFigureMaxHeight = figure.style.maxHeight;
-
-    versionRollout.style.overflow = "visible";
-    versionRollout.style.maxHeight = "none";
-    figure.style.maxHeight = "none";
-    return () => {
-      versionRollout.style.overflow = lastOverflow;
-      versionRollout.style.maxHeight = lastMaxHeight;
-      figure.style.maxHeight = lastFigureMaxHeight;
-    };
-  }
 
   const reset = updateStyle();
 
@@ -48,7 +47,7 @@ const copyImage = (event: MouseEvent<HTMLButtonElement>) => {
     {
       loading: "Rendering image...",
       success: "Image copied to clipboard",
-      error: "Failed to render image",
+      error: (err) => err.message,
     },
   );
 };

--- a/src/components/embed-frame.tsx
+++ b/src/components/embed-frame.tsx
@@ -16,6 +16,7 @@ export const EmbedFrame: React.FC<EmbedFrameProps> = ({
 }) => {
   return (
     <section
+      id="embed-frame"
       className={twMerge(
         "relative rounded border shadow-md",
         isError

--- a/src/components/npm-package/index.tsx
+++ b/src/components/npm-package/index.tsx
@@ -162,7 +162,10 @@ const VersionRollout: React.FC<VersionRolloutProps> = ({
   );
   return (
     <>
-      <div className="px-4 pb-2 text-xs">
+      <div
+        className="px-4 mb-2 text-xs max-h-72 overflow-auto"
+        id="version-rollout"
+      >
         <p className="mb-1 flex text-gray-500">
           Version rollout
           <span className="ml-auto">Last week</span>


### PR DESCRIPTION
continue #3 

appearance

<img src='https://github.com/himself65/npm-download-stat/assets/38493346/bb395a0d-3682-41fc-980c-3ff69b8c843b' width='350'>

generated image

<img src='https://github.com/himself65/npm-download-stat/assets/38493346/4fd9034f-1c7e-499f-99b4-5e6cbe050002' width='350'>

