### PR TITLE
fix: download image for firefox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,4 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run lint
-      - run: pnpm run format
+      - run: pnpm run ci

--- a/src/components/copy-image.tsx
+++ b/src/components/copy-image.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 
 function updateStyle() {
   const versionRollout = document.querySelector(
-    "#version-rollout"
+    "#version-rollout",
   ) as HTMLElement | null;
   const figure = document.querySelector("figure");
   if (
@@ -51,7 +51,7 @@ const copyImage = (event: MouseEvent<HTMLButtonElement>) => {
         loading: "Rendering image...",
         success: "Image copied to clipboard",
         error: (err) => err.message,
-      }
+      },
     );
   } else {
     let xpath = "//details//div";
@@ -60,7 +60,7 @@ const copyImage = (event: MouseEvent<HTMLButtonElement>) => {
       document,
       null,
       XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
-      null
+      null,
     );
 
     //removing yarn and npm entries as in the downloaded image they overlap with other content
@@ -86,7 +86,7 @@ const copyImage = (event: MouseEvent<HTMLButtonElement>) => {
         success:
           "Image downloaded, copying to clipboard is not supported in your browser",
         error: (err) => err.message,
-      }
+      },
     );
   }
 };

--- a/src/components/copy-image.tsx
+++ b/src/components/copy-image.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 
 function updateStyle() {
   const versionRollout = document.querySelector(
-    "#version-rollout",
+    "#version-rollout"
   ) as HTMLElement | null;
   const figure = document.querySelector("figure");
   if (
@@ -37,19 +37,58 @@ const copyImage = (event: MouseEvent<HTMLButtonElement>) => {
 
   const reset = updateStyle();
 
-  toast.promise(
-    toBlob(div).then(async (blob) => {
-      if (!blob) throw new Error("Failed to convert html to blob");
-      const item = new ClipboardItem({ "image/png": blob });
-      await navigator.clipboard.write([item]);
-      reset();
-    }),
-    {
-      loading: "Rendering image...",
-      success: "Image copied to clipboard",
-      error: (err) => err.message,
-    },
-  );
+  //Firefox does not support copying images to clipboard
+  if (typeof ClipboardItem !== "undefined") {
+    toast.promise(
+      toBlob(div).then(async (blob) => {
+        if (!blob) throw new Error("Failed to convert html to blob");
+        const item = new ClipboardItem({ "image/png": blob });
+        await navigator.clipboard.write([item]);
+
+        reset();
+      }),
+      {
+        loading: "Rendering image...",
+        success: "Image copied to clipboard",
+        error: (err) => err.message,
+      }
+    );
+  } else {
+    let xpath = "//details//div";
+    let matchingElements = document.evaluate(
+      xpath,
+      document,
+      null,
+      XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+      null
+    );
+
+    //removing yarn and npm entries as in the downloaded image they overlap with other content
+    for (let i = 0; i < matchingElements.snapshotLength; i++) {
+      let element = matchingElements.snapshotItem(i);
+      if (element && element.parentNode) {
+        element.parentNode.removeChild(element);
+      }
+    }
+    toast.promise(
+      toBlob(div).then(async (blob) => {
+        if (!blob) throw new Error("Failed to convert html to blob");
+        let tempElem = document.createElement("a");
+        tempElem.href = URL.createObjectURL(blob);
+        tempElem.download = "image.png";
+        document.body.appendChild(tempElem);
+        tempElem.click();
+        document.body.removeChild(tempElem);
+        reset();
+      }),
+      {
+        loading: "Rendering image...",
+        success:
+          "Image downloaded, copying to clipboard is not supported in your browser",
+        error: (err) => err.message,
+      }
+    );
+  }
 };
 
 export function CopyImage() {

--- a/src/section/search-bar.tsx
+++ b/src/section/search-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useId } from "react";
-import SearchButton from "./search-button"; 
+import SearchButton from "./search-button";
 
 export function SearchBar() {
   const idPrefix = useId();


### PR DESCRIPTION
Hacky attempt but would be nice to get images in Firefox too.

Closes https://github.com/himself65/npm-download-stat/issues/24
 
Attempts to find if ClipboardItem exists, if not, downloads the image as copying to clipboard is not supported.

Removing the yarn and npm lines is required otherwise the text overlaps other sections.

![image(8)](https://github.com/himself65/npm-download-stat/assets/107583272/a8339813-9680-4cef-96f1-ec4c3c7509f9)
