### PR TITLE
fix: license fallback to npm

### DIFF
--- a/src/components/npm-package/index.tsx
+++ b/src/components/npm-package/index.tsx
@@ -83,10 +83,20 @@ export const NpmPackage: React.FC<NpmPackageProps> = async ({
                     <span>{version}</span>
                   </dl>
                 )}
-                {github.license && (
+                {github.license ? (
                   <dl className="flex items-center gap-1" title="License">
                     <FiFileText />
-                    <dd>{github.license.split(" ")[0]}</dd>
+                    <dd>
+                      {github.license.split(" ")[0].toUpperCase() ===
+                      "NOASSERTION"
+                        ? npm.license
+                        : github.license.split(" ")[0]}
+                    </dd>
+                  </dl>
+                ) : (
+                  <dl className="flex items-center gap-1" title="License">
+                    <FiFileText />
+                    <dd>{npm.license}</dd>
                   </dl>
                 )}
               </div>

--- a/src/lib/fetch-npm.ts
+++ b/src/lib/fetch-npm.ts
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 
 export type NpmPackageStatsData = {
   packageName: string;
+  license: string;
   url: string;
   repository?: string;
   allTime: number;
@@ -85,6 +86,7 @@ export async function getPkgInfo(pkg: string) {
     homepage?: string;
     description: string;
     version: string;
+    license: string;
     repository?: {
       url: string;
     };
@@ -94,14 +96,20 @@ export async function getPkgInfo(pkg: string) {
 export async function fetchNpmPackage(
   pkg: string,
 ): Promise<NpmPackageStatsData> {
-  const [allTime, { downloads: last30Days, date: lastDate }, versions] =
-    await Promise.all([
-      getAllTime(pkg),
-      getLastNDays(pkg, 30),
-      getVersions(pkg),
-    ]);
+  const [
+    { license },
+    allTime,
+    { downloads: last30Days, date: lastDate },
+    versions,
+  ] = await Promise.all([
+    getPkgInfo(pkg),
+    getAllTime(pkg),
+    getLastNDays(pkg, 30),
+    getVersions(pkg),
+  ]);
   return {
     packageName: pkg,
+    license,
     url: `https://npmjs.com/package/${pkg}`,
     versions,
     allTime,


### PR DESCRIPTION
Fixes: https://github.com/himself65/npm-download-stat/issues/30

https://npm-download-stat-git-fix-license-alex-yang.vercel.app/%40adamlui%2Fminify.js
