### PR TITLE
fix: remove all download count

### DIFF
--- a/src/components/npm-package/index.tsx
+++ b/src/components/npm-package/index.tsx
@@ -2,7 +2,7 @@
 import { fetchRepository } from "@/lib/fetch-github";
 import { fetchNpmPackage } from "@/lib/fetch-npm";
 import React from "react";
-import { FiDownload, FiFileText, FiStar, FiTag } from "react-icons/fi";
+import { FiFileText, FiStar, FiTag } from "react-icons/fi";
 import { compareBuild } from "semver";
 
 import { twMerge } from "tailwind-merge";
@@ -45,7 +45,7 @@ export const NpmPackage: React.FC<NpmPackageProps> = async ({
           <br />
           GitHub updated at: {github.updatedAt.toISOString()}
         </data>
-        <figure className="not-prose my-2 max-w-[433px] max-h-[600px]">
+        <figure className="not-prose my-4 max-w-[433px] max-h-[600px]">
           <div className="px-4">
             <header
               className="mb-2 flex flex-wrap justify-between gap-2"
@@ -61,13 +61,6 @@ export const NpmPackage: React.FC<NpmPackageProps> = async ({
                 <dl className="flex items-center gap-1" title="Stars">
                   <FiStar />
                   <dd>{formatStatNumber(github.stars)}</dd>
-                </dl>
-                <dl
-                  className="flex items-center gap-1"
-                  title="NPM downloads (all time)"
-                >
-                  <FiDownload />
-                  <dd>{formatStatNumber(npm.allTime)}</dd>
                 </dl>
                 {version && (
                   <dl

--- a/src/lib/fetch-npm.ts
+++ b/src/lib/fetch-npm.ts
@@ -6,7 +6,6 @@ export type NpmPackageStatsData = {
   license: string;
   url: string;
   repository?: string;
-  allTime: number;
   last30Days: number[];
   versions: Record<string, number>;
   lastDate: Date;
@@ -94,12 +93,10 @@ export async function fetchNpmPackage(
 ): Promise<NpmPackageStatsData> {
   const [
     { license },
-    allTime,
     { downloads: last30Days, date: lastDate },
     versions,
   ] = await Promise.all([
     getPkgInfo(pkg),
-    getAllTime(pkg),
     getLastNDays(pkg, 30),
     getVersions(pkg),
   ]);
@@ -108,7 +105,6 @@ export async function fetchNpmPackage(
     license,
     url: `https://npmjs.com/package/${pkg}`,
     versions,
-    allTime,
     lastDate: new Date(lastDate),
     last30Days,
     updatedAt: new Date(),

--- a/src/lib/fetch-npm.ts
+++ b/src/lib/fetch-npm.ts
@@ -91,15 +91,12 @@ export async function getPkgInfo(pkg: string) {
 export async function fetchNpmPackage(
   pkg: string,
 ): Promise<NpmPackageStatsData> {
-  const [
-    { license },
-    { downloads: last30Days, date: lastDate },
-    versions,
-  ] = await Promise.all([
-    getPkgInfo(pkg),
-    getLastNDays(pkg, 30),
-    getVersions(pkg),
-  ]);
+  const [{ license }, { downloads: last30Days, date: lastDate }, versions] =
+    await Promise.all([
+      getPkgInfo(pkg),
+      getLastNDays(pkg, 30),
+      getVersions(pkg),
+    ]);
   return {
     packageName: pkg,
     license,


### PR DESCRIPTION
The main goal of this project is to see what versions users are using. The all-download count is not officially supported by npm API, but there's some workaround for it, which uses a for-loop to get all-day downloads. I'm stopping using this because this feature sends too many requests.